### PR TITLE
Unit test example for redux component

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "karma-sourcemap-writer": "^0.1.2",
     "karma-spec-reporter": "0.0.26",
     "karma-webpack": "^1.7.0",
-    "ng2-redux": "^3.0.7",
+    "ng2-redux": "^3.0.8-beta.0",
     "nodemon": "^1.9.2",
     "passport": "^0.3.2",
     "passport-local": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "karma-sourcemap-writer": "^0.1.2",
     "karma-spec-reporter": "0.0.26",
     "karma-webpack": "^1.7.0",
-    "ng2-redux": "^3.0.8-beta.0",
+    "ng2-redux": "^3.0.8-beta.2",
     "nodemon": "^1.9.2",
     "passport": "^0.3.2",
     "passport-local": "^1.0.0",

--- a/src/containers/counter-page.test.ts
+++ b/src/containers/counter-page.test.ts
@@ -1,0 +1,76 @@
+import {
+  async,
+  beforeEach,
+  beforeEachProviders,
+  describe,
+  expect,
+  it,
+  inject,
+} from '@angular/core/testing';
+import { ComponentFixture, TestComponentBuilder }
+from '@angular/compiler/testing';
+import { Component, provide } from '@angular/core';
+import { By } from '@angular/platform-browser';
+import { RioCounterPage } from './counter-page';
+import { CounterActions } from '../actions/counter';
+import {NgRedux} from 'ng2-redux';
+import {fromJS} from 'immutable';
+import { counterReducer  as counter } from '../reducers/counter';
+import { combineReducers } from 'redux';
+describe('Container: Counter', () => {
+  let builder: TestComponentBuilder;
+
+
+  beforeEachProviders(() => [RioCounterPage, CounterActions, provide(NgRedux, {
+    useFactory: () => {
+      let ngRedux = new NgRedux(null);
+      ngRedux.configureStore(combineReducers<any>({ counter }), {});
+      return ngRedux;
+    }
+  })]);
+  beforeEach(inject([TestComponentBuilder],
+    function (tcb: TestComponentBuilder) {
+      builder = tcb;
+    }));
+
+  it('Should not explode', inject([RioCounterPage],
+    (component: RioCounterPage) => {
+      component.increment();
+
+
+    }));
+
+  it('should get initial counter state',
+    async(inject([], () => {
+      return builder
+        .overrideTemplate(RioCounterPage, `<div>{{counter$ | async}}</div>`)
+        .createAsync(RioCounterPage)
+        .then((fixture: ComponentFixture<RioCounterPage>) => {
+          const compiled = fixture.debugElement.nativeElement;
+          fixture.detectChanges();
+          fixture.whenStable().then(() => {
+            expect(compiled.querySelector('div')).toHaveText('0');
+          });
+
+        });
+    })));
+  
+  it('should subscribe to state', async(inject([], () => {
+      return builder
+        .overrideTemplate(RioCounterPage, `<div>{{counter$ | async}}</div>`)
+        .createAsync(RioCounterPage)
+        .then((fixture: ComponentFixture<RioCounterPage>) => {
+          const compiled = fixture.debugElement.nativeElement;
+          fixture.componentInstance.increment();
+          fixture.detectChanges();
+          fixture.whenStable().then(() => {
+            expect(compiled.querySelector('div')).toHaveText('1');
+          });
+
+        });
+    })));
+
+
+
+});
+

--- a/src/containers/counter-page.ts
+++ b/src/containers/counter-page.ts
@@ -1,10 +1,11 @@
 import { Component, Inject, ApplicationRef } from '@angular/core';
 import { AsyncPipe } from '@angular/common';
 import { bindActionCreators } from 'redux';
-import { select } from 'ng2-redux';
+import { select, NgRedux } from 'ng2-redux';
 import { CounterActions } from '../actions/counter';
 import { Observable } from 'rxjs/Observable';
 import { RioContainer, RioCounter } from '../components';
+import { IAppState } from '../reducers';
 
 @Component({
   selector: 'counter-page',
@@ -29,5 +30,10 @@ import { RioContainer, RioCounter } from '../components';
 export class RioCounterPage {
   @select(n => n.counter.get('count')) private counter$: Observable<number>;
 
-  constructor(private actions: CounterActions) {}
+  constructor(private actions: CounterActions,
+    private ngRedux: NgRedux<IAppState>) { }
+  
+  increment() {
+    this.ngRedux.dispatch({ type: CounterActions.INCREMENT_COUNTER });
+  }
 }


### PR DESCRIPTION
Show how to bootstrap a component that requires ngRedux to be injected.
When we changed how to bootstrap an app with v3, we didn't provide
examples of how to do this.

Required minor update to ng2-redux also to allow for app ref to be
optional.
