### PR TITLE
Break sample-app.module.ts into smaller modules

### DIFF
--- a/src/app/sample-app.module.ts
+++ b/src/app/sample-app.module.ts
@@ -10,70 +10,32 @@ import {
   routing,
   appRoutingProviders
 } from './sample-app.routing';
-import {HttpModule} from '@angular/http';
-import {
-  FormBuilder,
-  ReactiveFormsModule
-} from '@angular/forms';
+import {FormBuilder} from '@angular/forms';
 import {RioSampleApp} from './sample-app';
 import {SessionActions} from '../actions/session.actions';
 import {SessionEpics} from '../epics/session.epics';
 import {
-  RioLoginForm,
-  RioLoginModal
-} from '../components/login';
-import {
-  RioModalContent,
-  RioModal
-} from '../components/modal';
-import {
-  RioInput,
-  RioFormGroup,
-  RioFormError,
-  RioForm,
-  RioLabel
-} from '../components/form';
-import {
-  RioNavigator,
-  RioNavigatorItem
-} from '../components/navigator';
-import {RioAlert} from '../components/alert/alert.component';
-import {RioButton} from '../components/button/button.component';
-import {RioLogo} from '../components/logo/logo.component';
-import {RioAboutPage} from '../pages/about.page';
-import {RioCounterPage} from '../pages/counter.page';
-import {RioContainer} from '../components/container/container.component';
+  RioAboutPage,
+  RioCounterPage
+} from '../pages';
 import {RioCounter} from '../components/counter/counter.component';
+import {RioLoginModule} from '../components/login/login.module';
+import {RioUiModule} from '../components/ui/ui.module';
+import {RioNavigatorModule} from '../components/navigator/navigator.module';
 
 @NgModule({
   imports: [
     BrowserModule,
     routing,
-    ReactiveFormsModule,
     CommonModule,
-    HttpModule
+    RioLoginModule,
+    RioUiModule,
+    RioNavigatorModule
   ],
   declarations: [
     RioSampleApp,
-    RioModal,
-    RioLoginModal,
-    RioLoginForm,
-    RioModalContent,
-    RioAlert,
-    RioButton,
-    RioInput,
-    RioForm,
-    RioFormError,
-    RioFormGroup,
-    RioLabel,
-    RioNavigator,
-    RioNavigatorItem,
-    RioLoginModal,
-    RioLogo,
-    RioButton,
     RioAboutPage,
     RioCounterPage,
-    RioContainer,
     RioCounter
   ],
   bootstrap: [

--- a/src/components/alert/alert.component.test.ts
+++ b/src/components/alert/alert.component.test.ts
@@ -2,17 +2,18 @@ import {
   async,
   inject
 } from '@angular/core/testing';
-import { RioAlert } from './alert.component';
+import {RioAlert} from './alert.component';
 import {TestBed} from '@angular/core/testing/test_bed';
+import {RioUiModule} from '../ui/ui.module';
 
 describe('Component: Alert', () => {
   let fixture;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [
-        RioAlert
-      ],
+      imports: [
+        RioUiModule
+      ]
     });
     fixture = TestBed.createComponent(RioAlert);
     fixture.detectChanges();

--- a/src/components/button/button.component.test.ts
+++ b/src/components/button/button.component.test.ts
@@ -2,16 +2,17 @@ import {
   async,
   inject
 } from '@angular/core/testing';
-import { RioButton } from './button.component';
+import {RioButton} from './button.component';
 import {TestBed} from '@angular/core/testing/test_bed';
+import {RioUiModule} from '../ui/ui.module';
 
 let fixture;
 
 describe('Component: Button', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [
-        RioButton
+      imports: [
+        RioUiModule
       ]
     });
     fixture = TestBed.createComponent(RioButton);

--- a/src/components/container/container.component.test.ts
+++ b/src/components/container/container.component.test.ts
@@ -2,8 +2,9 @@ import {
   async,
   inject
 } from '@angular/core/testing';
-import { RioContainer } from './container.component';
+import {RioContainer} from './container.component';
 import {TestBed} from '@angular/core/testing/test_bed';
+import {RioUiModule} from '../ui/ui.module';
 
 describe('Component: Alert', () => {
 
@@ -11,8 +12,8 @@ describe('Component: Alert', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [
-        RioContainer
+      imports: [
+        RioUiModule
       ]
     });
     fixture = TestBed.createComponent(RioContainer);

--- a/src/components/counter/counter.component.ts
+++ b/src/components/counter/counter.component.ts
@@ -6,7 +6,6 @@ import {
   ChangeDetectionStrategy,
 } from '@angular/core';
 import { ICounter } from '../../store';
-import { RioButton } from '../button';
 
 @Component({
   selector: 'rio-counter',
@@ -32,7 +31,6 @@ import { RioButton } from '../button';
       </rio-button>
     </div>
   `,
-  directives: [RioButton],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class RioCounter {

--- a/src/components/form/form-error.test.ts
+++ b/src/components/form/form-error.test.ts
@@ -3,8 +3,8 @@ import {
   inject
 } from '@angular/core/testing';
 import { RioFormError } from './form-error';
-import {ReactiveFormsModule} from '@angular/forms';
 import {TestBed} from '@angular/core/testing/test_bed';
+import {RioFormModule} from './form.module';
 
 describe('Component: Form Error', () => {
   let fixture;
@@ -12,10 +12,7 @@ describe('Component: Form Error', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
-        ReactiveFormsModule
-      ],
-      declarations: [
-        RioFormError
+        RioFormModule
       ]
     });
     fixture = TestBed.createComponent(RioFormError);

--- a/src/components/form/form-group.test.ts
+++ b/src/components/form/form-group.test.ts
@@ -2,11 +2,11 @@ import {
   async,
   inject,
 } from '@angular/core/testing';
-import { Component } from '@angular/core';
-import { By } from '@angular/platform-browser';
-import { RioFormGroup } from './form-group';
+import {Component} from '@angular/core';
+import {By} from '@angular/platform-browser';
+import {RioFormGroup} from './form-group';
 import {TestBed} from '@angular/core/testing/test_bed';
-import {ReactiveFormsModule} from '@angular/forms';
+import {RioFormModule} from './form.module';
 
 describe('Component: Navigator', () => {
   let fixture;
@@ -14,10 +14,9 @@ describe('Component: Navigator', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
-        ReactiveFormsModule
+        RioFormModule
       ],
       declarations: [
-        RioFormGroup,
         RioFormGroupTestController
       ],
       providers: [

--- a/src/components/form/form.module.ts
+++ b/src/components/form/form.module.ts
@@ -1,0 +1,32 @@
+import {NgModule}      from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {ReactiveFormsModule} from '@angular/forms';
+import {
+  RioForm,
+  RioFormGroup,
+  RioFormError,
+  RioInput,
+  RioLabel
+} from './index';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    ReactiveFormsModule
+  ],
+  declarations: [
+    RioForm,
+    RioFormGroup,
+    RioFormError,
+    RioLabel,
+    RioInput
+  ],
+  exports: [
+    RioForm,
+    RioFormGroup,
+    RioFormError,
+    RioLabel,
+    RioInput
+  ]
+})
+export class RioFormModule { }

--- a/src/components/form/form.test.ts
+++ b/src/components/form/form.test.ts
@@ -2,9 +2,9 @@ import {
   async,
   inject,
 } from '@angular/core/testing';
-import { Component } from '@angular/core';
-import { By } from '@angular/platform-browser';
-import { RioForm } from './form';
+import {Component} from '@angular/core';
+import {By} from '@angular/platform-browser';
+import {RioForm} from './form';
 import {
   FormGroup,
   FormControl,
@@ -12,6 +12,7 @@ import {
   ReactiveFormsModule
 } from '@angular/forms';
 import {TestBed} from '@angular/core/testing/test_bed';
+import {RioFormModule} from './form.module';
 
 describe('Component: Form', () => {
   let fixture;
@@ -19,10 +20,10 @@ describe('Component: Form', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
+        RioFormModule,
         ReactiveFormsModule
       ],
       declarations: [
-        RioForm,
         RioFormTestController
       ],
       providers: [

--- a/src/components/form/input.test.ts
+++ b/src/components/form/input.test.ts
@@ -4,10 +4,10 @@ import {
 } from '@angular/core/testing';
 import { RioInput } from './input';
 import {
-  FormControl,
-  ReactiveFormsModule
+  FormControl
 } from '@angular/forms';
 import {TestBed} from '@angular/core/testing/test_bed';
+import {RioFormModule} from './form.module';
 
 describe('Component: Form Input', () => {
   let fixture;
@@ -15,10 +15,7 @@ describe('Component: Form Input', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
-        ReactiveFormsModule
-      ],
-      declarations: [
-        RioInput
+        RioFormModule
       ]
     });
     fixture = TestBed.createComponent(RioInput);

--- a/src/components/form/label.test.ts
+++ b/src/components/form/label.test.ts
@@ -6,14 +6,17 @@ import { Component } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { RioLabel } from './label';
 import {TestBed} from '@angular/core/testing/test_bed';
+import {RioFormModule} from './form.module';
 
 describe('Component: Navigator', () => {
   let fixture;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
+      imports: [
+        RioFormModule
+      ],
       declarations: [
-        RioLabel,
         RioLabelTestController
       ],
       providers: [

--- a/src/components/login/login-form.test.ts
+++ b/src/components/login/login-form.test.ts
@@ -2,32 +2,17 @@ import {
   async,
   inject
 } from '@angular/core/testing';
-import { RioLoginForm } from './index';
-import {
-  ReactiveFormsModule
-} from '@angular/forms';
+import {RioLoginForm} from './index';
 import {TestBed} from '@angular/core/testing/test_bed';
-import {
-  RioForm,
-  RioInput,
-  RioFormError,
-} from '../form';
-import {RioButton} from '../button/button.component';
-import {RioAlert} from '../alert/alert.component';
+import {RioLoginModule} from './login.module';
 
 describe('Component: Login Form', () => {
   let fixture;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ReactiveFormsModule],
-      declarations: [
-        RioLoginForm,
-        RioForm,
-        RioInput,
-        RioFormError,
-        RioButton,
-        RioAlert
+      imports: [
+        RioLoginModule
       ]
     });
     fixture = TestBed.createComponent(RioLoginForm);

--- a/src/components/login/login-modal.test.ts
+++ b/src/components/login/login-modal.test.ts
@@ -2,36 +2,17 @@ import {
   async,
   inject
 } from '@angular/core/testing';
-import {
-  RioLoginModal,
-  RioLoginForm
-} from './index';
-import {
-  ReactiveFormsModule
-} from '@angular/forms';
+import {RioLoginModal} from './index';
+import {RioLoginModule} from './login.module';
 import {TestBed} from '@angular/core/testing/test_bed';
-import {
-  RioForm,
-  RioInput,
-  RioFormError
-} from '../form';
 
 describe('Component: Login Modal', () => {
   let fixture;
 
-  /*
-   * Interesting to note, building up a test bed like this really
-   * helps inform what could - or should - be a module.
-   */
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ReactiveFormsModule],
-      declarations: [
-        RioLoginModal,
-        RioLoginForm,
-        RioForm,
-        RioInput,
-        RioFormError
+      imports: [
+        RioLoginModule
       ]
     });
     fixture = TestBed.createComponent(RioLoginModal);

--- a/src/components/login/login.module.ts
+++ b/src/components/login/login.module.ts
@@ -1,0 +1,32 @@
+import {NgModule}      from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {HttpModule} from '@angular/http';
+import {
+  ReactiveFormsModule
+} from '@angular/forms';
+import {
+  RioLoginForm,
+  RioLoginModal
+} from '../index';
+import {RioUiModule} from '../ui/ui.module';
+import {RioModalModule} from '../modal/modal.module';
+import {RioFormModule} from '../form/form.module';
+
+@NgModule({
+  imports: [
+    ReactiveFormsModule,
+    CommonModule,
+    HttpModule,
+    RioUiModule,
+    RioModalModule,
+    RioFormModule
+  ],
+  declarations: [
+    RioLoginModal,
+    RioLoginForm
+  ],
+  exports: [
+    RioLoginModal
+  ]
+})
+export class RioLoginModule { }

--- a/src/components/logo/logo.component.test.ts
+++ b/src/components/logo/logo.component.test.ts
@@ -2,16 +2,17 @@ import {
   async,
   inject
 } from '@angular/core/testing';
-import { RioLogo } from './index';
+import {RioLogo} from './index';
 import {TestBed} from '@angular/core/testing/test_bed';
+import {RioUiModule} from '../ui/ui.module';
 
 describe('Component: Logo', () => {
   let fixture;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [
-        RioLogo
+      imports: [
+        RioUiModule
       ]
     });
     fixture = TestBed.createComponent(RioLogo);

--- a/src/components/modal/modal-content.component.test.ts
+++ b/src/components/modal/modal-content.component.test.ts
@@ -1,18 +1,21 @@
 import {
   inject
 } from '@angular/core/testing';
-import { Component } from '@angular/core';
-import { By } from '@angular/platform-browser';
-import { RioModalContent } from './modal-content.component';
+import {Component} from '@angular/core';
+import {By} from '@angular/platform-browser';
+import {RioModalContent} from './modal-content.component';
 import {TestBed} from '@angular/core/testing/test_bed';
+import {RioModalModule} from './modal.module';
 
 describe('Component: Modal Content', () => {
   let fixture;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
+      imports: [
+        RioModalModule
+      ],
       declarations: [
-        RioModalContent,
         RioModalContentTestController
       ],
       providers: [

--- a/src/components/modal/modal.component.test.ts
+++ b/src/components/modal/modal.component.test.ts
@@ -2,18 +2,21 @@ import {
   async,
   inject
 } from '@angular/core/testing';
-import { Component } from '@angular/core';
-import { By } from '@angular/platform-browser';
-import { RioModal } from './modal.component';
+import {Component} from '@angular/core';
+import {By} from '@angular/platform-browser';
+import {RioModal} from './modal.component';
 import {TestBed} from '@angular/core/testing/test_bed';
+import {RioModalModule} from './modal.module';
 
 describe('Component: Modal', () => {
   let fixture;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
+      imports: [
+        RioModalModule
+      ],
       declarations: [
-        RioModal,
         RioModalTestController
       ],
       providers: [

--- a/src/components/modal/modal.module.ts
+++ b/src/components/modal/modal.module.ts
@@ -1,0 +1,19 @@
+import {NgModule}      from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {RioModal} from './modal.component';
+import {RioModalContent} from './modal-content.component';
+
+@NgModule({
+  imports: [
+    CommonModule
+  ],
+  declarations: [
+    RioModal,
+    RioModalContent
+  ],
+  exports: [
+    RioModal,
+    RioModalContent
+  ]
+})
+export class RioModalModule { }

--- a/src/components/navigator/navigator-item.component.test.ts
+++ b/src/components/navigator/navigator-item.component.test.ts
@@ -2,8 +2,9 @@ import {
   async,
   inject
 } from '@angular/core/testing';
-import { RioNavigatorItem } from './navigator-item.component';
+import {RioNavigatorItem} from './navigator-item.component';
 import {TestBed} from '@angular/core/testing/test_bed';
+import {RioNavigatorModule} from './navigator.module';
 
 
 describe('Component: Navigator Item', () => {
@@ -11,8 +12,8 @@ describe('Component: Navigator Item', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [
-        RioNavigatorItem
+      imports: [
+        RioNavigatorModule
       ]
     });
     fixture = TestBed.createComponent(RioNavigatorItem);

--- a/src/components/navigator/navigator.component.test.ts
+++ b/src/components/navigator/navigator.component.test.ts
@@ -2,18 +2,21 @@ import {
   async,
   inject
 } from '@angular/core/testing';
-import { Component } from '@angular/core';
-import { By } from '@angular/platform-browser';
-import { RioNavigator } from './navigator.component';
+import {Component} from '@angular/core';
+import {By} from '@angular/platform-browser';
+import {RioNavigator} from './navigator.component';
 import {TestBed} from '@angular/core/testing/test_bed';
+import {RioNavigatorModule} from './navigator.module';
 
 describe('Component: Navigator', () => {
   let fixture;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
+      imports: [
+        RioNavigatorModule
+      ],
       declarations: [
-        RioNavigator,
         RioNavigatorTestController
       ],
       providers: [

--- a/src/components/navigator/navigator.module.ts
+++ b/src/components/navigator/navigator.module.ts
@@ -1,0 +1,23 @@
+import {NgModule}      from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {ReactiveFormsModule} from '@angular/forms';
+import {
+  RioNavigator,
+  RioNavigatorItem
+} from './index';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    ReactiveFormsModule
+  ],
+  declarations: [
+    RioNavigator,
+    RioNavigatorItem
+  ],
+  exports: [
+    RioNavigator,
+    RioNavigatorItem
+  ]
+})
+export class RioNavigatorModule { }

--- a/src/components/ui/ui.module.ts
+++ b/src/components/ui/ui.module.ts
@@ -1,0 +1,25 @@
+import {NgModule}      from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {RioAlert} from '../alert/alert.component';
+import {RioButton} from '../button/button.component';
+import {RioLogo} from '../logo/logo.component';
+import {RioContainer} from '../container/container.component';
+
+@NgModule({
+  imports: [
+    CommonModule
+  ],
+  declarations: [
+    RioAlert,
+    RioButton,
+    RioLogo,
+    RioContainer
+  ],
+  exports: [
+    RioAlert,
+    RioButton,
+    RioLogo,
+    RioContainer
+  ]
+})
+export class RioUiModule { }


### PR DESCRIPTION
There are now 3 modules imported by sample-app.module.ts, and 2 modules imported by login.module.ts:

- ui.module.ts
- navigator.module.ts
- login.module.ts
  - form.module.ts
  - modal.module.ts

Now that we've moved to modules, it's probably worth taking another look at our folder structure.

Have also updated the tests to use modules instead of declarations. Definitely cleans stuff up nicely.