### PR TITLE
Upgrade to Angular 2.0.0 final / webpack 2.1.0-beta.25 / fix HTML code coverage reports

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -3,7 +3,6 @@
 process.env.TEST = true;
 
 const loaders = require('./webpack/loaders');
-const postcssInit = require('./webpack/postcss');
 const plugins = require('./webpack/plugins');
 
 module.exports = (config) => {
@@ -47,21 +46,19 @@ module.exports = (config) => {
 
     webpack: {
       plugins,
-      postcss: postcssInit,
       entry: './src/tests.entry.ts',
       devtool: 'inline-source-map',
-      verbose: false,
       resolve: {
-        extensions: ['', '.webpack.js', '.web.js', '.ts', '.js'],
+        extensions: ['.webpack.js', '.web.js', '.ts', '.js'],
       },
       module: {
-        loaders: combinedLoaders(),
-        postLoaders: config.singleRun
-          ? [ loaders.istanbulInstrumenter ]
-          : [ ],
+        rules:
+          combinedLoaders().concat(
+            config.singleRun
+              ? [ loaders.istanbulInstrumenter ]
+              : [ ]),
       },
       stats: { colors: true, reasons: true },
-      debug: false,
     },
 
     webpackServer: {
@@ -72,13 +69,6 @@ module.exports = (config) => {
       .concat(coverage)
       .concat(coverage.length > 0 ? ['karma-remap-istanbul'] : []),
 
-    remapIstanbulReporter: {
-      src: 'coverage/chrome/coverage-final.json',
-      reports: {
-        html: 'coverage',
-      },
-    },
-
     coverageReporter: {
       reporters: [
         { type: 'json' },
@@ -86,6 +76,13 @@ module.exports = (config) => {
       dir: './coverage/',
       subdir: (browser) => {
         return browser.toLowerCase().split(/[ /-]/)[0]; // returns 'chrome'
+      },
+    },
+
+    remapIstanbulReporter: {
+      src: './coverage/chrome/coverage-final.json',
+      reports: {
+        html: 'coverage',
       },
     },
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -84,6 +84,7 @@ module.exports = (config) => {
       reports: {
         html: 'coverage',
       },
+      timeoutNotCreated: 5000,
     },
 
     port: 9999,

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "redux-observable": "^0.9.0",
     "reflect-metadata": "0.1.3",
     "rimraf": "^2.5.4",
-    "rxjs": "5.0.0-beta.6",
+    "rxjs": "5.0.0-beta.12",
     "style-loader": "^0.13.0",
     "stylelint": "^6.5.0",
     "stylelint-webpack-plugin": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -45,13 +45,13 @@
     "winston": "^2.1.1"
   },
   "devDependencies": {
-    "@angular/common": "2.0.0-rc.6",
-    "@angular/compiler": "2.0.0-rc.6",
-    "@angular/core": "2.0.0-rc.6",
-    "@angular/forms": "2.0.0-rc.6",
-    "@angular/http": "2.0.0-rc.6",
-    "@angular/platform-browser": "2.0.0-rc.6",
-    "@angular/platform-browser-dynamic": "2.0.0-rc.6",
+    "@angular/common": "2.0.0",
+    "@angular/compiler": "2.0.0",
+    "@angular/core": "2.0.0",
+    "@angular/forms": "2.0.0",
+    "@angular/http": "2.0.0",
+    "@angular/platform-browser": "2.0.0",
+    "@angular/platform-browser-dynamic": "2.0.0",
     "@angular/router": "^3.0.0-rc.2",
     "autoprefixer": "^6.3.3",
     "autoprefixer-core": "^6.0.1",
@@ -122,10 +122,10 @@
     "typed-immutable-record": "0.0.3",
     "typescript": "^2.0.0",
     "typings": "^1.0.4",
-    "webpack": "^2.1.0-beta.20",
-    "webpack-dev-server": "^2.1.0-beta.0",
-    "webpack-hot-middleware": "^2.12.2",
-    "webpack-split-by-path": "^0.1.0-beta.1",
+    "webpack": "2.1.0-beta.25",
+    "webpack-dev-server": "2.1.0-beta.5",
+    "webpack-hot-middleware": "2.12.2",
+    "webpack-split-by-path": "0.1.0-beta.1",
     "zone.js": "^0.6.17"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,6 @@ const path = require('path');
 const proxy = require('./server/webpack-dev-proxy');
 const loaders = require('./webpack/loaders');
 const plugins = require('./webpack/plugins');
-const postcssInit = require('./webpack/postcss');
 
 /*
  * Dev Config
@@ -85,9 +84,11 @@ const prodConfig = {
 };
 
 const baseConfig = {
-  resolve: { extensions: ['', '.webpack.js', '.web.js', '.ts', '.js'] },
+  resolve: {
+    extensions: ['.webpack.js', '.web.js', '.ts', '.js'],
+  },
+
   plugins: plugins,
-  postcss: postcssInit,
 
   devServer: {
     historyApiFallback: { index: '/' },
@@ -95,10 +96,8 @@ const baseConfig = {
   },
 
   module: {
-    preLoaders: [
+    rules: [
       loaders.tslint,
-    ],
-    loaders: [
       loaders.angular,
       loaders.ts,
       loaders.html,

--- a/webpack/loaders.js
+++ b/webpack/loaders.js
@@ -11,6 +11,7 @@ exports.angular = { // ships in ES6 format now
 };
 
 exports.tslint = {
+  enforce: 'pre',
   test: /\.ts$/,
   loader: 'tslint',
   exclude: /node_modules/,
@@ -27,6 +28,7 @@ exports.ts = {
 };
 
 exports.istanbulInstrumenter = {
+  enforce: 'post',
   test: /^(.(?!\.test))*\.ts$/,
   loader: 'istanbul-instrumenter-loader',
 };

--- a/webpack/plugins.js
+++ b/webpack/plugins.js
@@ -36,6 +36,8 @@ const basePlugins = [
       postcss,
     },
   }),
+  new webpack.ContextReplacementPlugin(
+    /angular\/core\/(esm\/src|src)\/linker/, __dirname),
 ].concat(sourceMap);
 
 const devPlugins = [

--- a/webpack/plugins.js
+++ b/webpack/plugins.js
@@ -7,6 +7,8 @@ const CopyWebpackPlugin = require('copy-webpack-plugin');
 const ForkCheckerPlugin =
   require('awesome-typescript-loader').ForkCheckerPlugin;
 
+const postcss = require('./postcss');
+
 const sourceMap = process.env.TEST
   ? [new webpack.SourceMapDevToolPlugin({ filename: null, test: /\.ts$/ })]
   : [ ];
@@ -28,6 +30,12 @@ const basePlugins = [
   new CopyWebpackPlugin([
     { from: 'src/assets', to: 'assets' },
   ]),
+  new webpack.LoaderOptionsPlugin({
+    test: /\.css$/,
+    options: {
+      postcss,
+    },
+  }),
 ].concat(sourceMap);
 
 const devPlugins = [


### PR DESCRIPTION
Upgrade to Angular 2.0.0 final
Upgrade to webpack 2.1.0-beta.25
Resolve issue with HTML code coverage reports not being generated